### PR TITLE
Adapt admin enterprise form for address and business_address

### DIFF
--- a/app/assets/javascripts/admin/enterprises/controllers/country_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/country_controller.js.coffee
@@ -1,5 +1,6 @@
 # Used in enterprise new and edit forms to reset the state when the country is changed
-angular.module("admin.enterprises").controller 'countryCtrl', ($scope, availableCountries) ->
+angular.module("admin.enterprises").controller 'countryCtrl', ($scope, $timeout, availableCountries) ->
+  $scope.address_type = "address"
   $scope.countries = availableCountries
 
   $scope.countriesById = $scope.countries.reduce (obj, country) ->
@@ -7,12 +8,13 @@ angular.module("admin.enterprises").controller 'countryCtrl', ($scope, available
     obj
   , {}
 
-  $scope.$watch 'Enterprise.address.country_id', (newID, oldID) ->
-    $scope.clearState() unless $scope.addressStateMatchesCountry()
+  $timeout ->
+    $scope.$watch 'Enterprise.' + $scope.address_type + '.country_id', (newID, oldID) ->
+      $scope.clearState() unless $scope.addressStateMatchesCountry()
 
   $scope.clearState = ->
-    $scope.Enterprise.address.state_id = null
+    $scope.Enterprise[$scope.address_type].state_id = null
 
   $scope.addressStateMatchesCountry = ->
-    $scope.countriesById[$scope.Enterprise.address.country_id].states.some (state) ->
-      state.id == $scope.Enterprise.address.state_id
+    $scope.countriesById[$scope.Enterprise[$scope.address_type].country_id].states.some (state) ->
+      state.id == $scope.Enterprise[$scope.address_type].state_id

--- a/app/serializers/api/admin/enterprise_serializer.rb
+++ b/app/serializers/api/admin/enterprise_serializer.rb
@@ -17,6 +17,7 @@ module Api
       has_one :owner, serializer: Api::Admin::UserSerializer
       has_many :users, serializer: Api::Admin::UserSerializer
       has_one :address, serializer: Api::AddressSerializer
+      has_one :business_address, serializer: Api::AddressSerializer
 
       def logo
         attachment_urls(object.logo, [:thumb, :small, :medium])

--- a/app/views/admin/enterprises/form/_business_address.html.haml
+++ b/app/views/admin/enterprises/form/_business_address.html.haml
@@ -28,10 +28,11 @@
     = bf.label :state_id, t(:state)
     \/
     = bf.label :country_id, t(:country)
-  .four.columns{ "ng-controller" => "countryCtrl" }
-    %input.ofn-select2.fullwidth#enterprise_address_attributes_state_id{ name: 'enterprise[address_attributes][state_id]', type: 'number', data: 'countriesById[Enterprise.address.country_id].states', placeholder: t('admin.choose'), ng: { model: 'Enterprise.address.state_id' } }
-  .four.columns.omega{ "ng-controller" => "countryCtrl" }
-    %input.ofn-select2.fullwidth#enterprise_address_attributes_country_id{ name: 'enterprise[address_attributes][country_id]', type: 'number', data: 'countries', placeholder: t('admin.choose'), ng: { model: 'Enterprise.address.country_id' } }
+  %div{ "ng-controller": "countryCtrl", "ng-init": "address_type='business_address'" }
+    .four.columns
+      %input.ofn-select2.fullwidth#enterprise_business_address_attributes_state_id{ name: 'enterprise[business_address_attributes][state_id]', type: 'number', data: 'countriesById[Enterprise.address.country_id].states', placeholder: t('admin.choose'), ng: { model: 'Enterprise.business_address.state_id' } }
+    .four.columns.omega{ "ng-controller" => "countryCtrl" }
+      %input.ofn-select2.fullwidth#enterprise_business_address_attributes_country_id{ name: 'enterprise[business_address_attributes][country_id]', type: 'number', data: 'countries', placeholder: t('admin.choose'), ng: { model: 'Enterprise.business_address.country_id' } }
 
 .row
   .three.columns.alpha


### PR DESCRIPTION
This was tricky!

The enterprise data is dumped into the page as JSON (defined in `Admin::EnterpriseSerializer`) which is then read by Angular and stored as a Javascript object. That object didn't have a business address, so it was being ignored.

I also adapted the Angular `countryCtrl` so that it can handle two separate address types on the same page at the same time. Previously it was trying to store the attributes for both addresses in one address object, so they overlapped.